### PR TITLE
Fix missing gap in credits

### DIFF
--- a/app/src/components/credits.tsx
+++ b/app/src/components/credits.tsx
@@ -18,7 +18,7 @@ export default function Credits(props:{
 
     {props.secondary.length !== 0 ? <div style={{display:'flex', flexFlow:'column', justifyContent:'space-between'}}>
         <p style={{fontSize:'0.7em'}}>Others</p>
-        <div style={{display:'flex', justifyContent:'space-around'}}>
+        <div style={{display:'flex', justifyContent:'space-around', gap:'0.7em'}}>
             {props.secondary.map(s=>findCredits(s))}
         </div>
     </div> : null}


### PR DESCRIPTION
Padding was missing in the credits section for portraits or sprites with three or more contributors