### PR TITLE
thumbnail take as much place as needed on the carousel

### DIFF
--- a/app/src/components/pokemon-thumbnail.tsx
+++ b/app/src/components/pokemon-thumbnail.tsx
@@ -78,7 +78,7 @@ export default function PokemonThumbnail(props: {
     }
 
     return <Link to={props.infoKey.toString()} className='my-link'>
-        <div className='my-container nes-container nes-pointer grow' style={{display:'flex', flexFlow:'column', justifyContent:'space-between', alignItems:'center', minWidth: '100px', maxWidth: '100px', margin:'10px'}}>
+        <div className='my-container nes-container nes-pointer grow' style={{display:'flex', flexFlow:'column', justifyContent:'space-between', alignItems:'center', minWidth: '100px', margin:'10px'}}>
              {image}
             <p style={{fontSize: '0.55em', margin: '0px'}}>{props.info.name}</p>
             {index}


### PR DESCRIPTION
I once did a PR for this, but someone put maxWidth = minWidth. Just removed the maxWidth. It seems to work well (and fix the display when sprite and/or portrait author is displayed)

![image](https://user-images.githubusercontent.com/22586596/172200159-a305835f-f349-493c-9719-9cf156e61469.png)
