### PR TITLE
grid layout for search parameters

### DIFF
--- a/app/src/components/display-parameters.tsx
+++ b/app/src/components/display-parameters.tsx
@@ -15,7 +15,7 @@ export default function DisplayParameters(props: {
   showSpriteBounty: boolean
 }) {
   return (
-    <div style={{ display: "flex", flexFlow: "column", alignItems: "start" }}>
+    <div style={{ display: "grid", gridTemplateColumns: '200px '.repeat(2), flexFlow: "column", alignItems: "start" }}>
       <label className="my-label">
         <input
           type="checkbox"

--- a/app/src/components/display-parameters.tsx
+++ b/app/src/components/display-parameters.tsx
@@ -15,7 +15,7 @@ export default function DisplayParameters(props: {
   showSpriteBounty: boolean
 }) {
   return (
-    <div style={{ display: "grid", gridTemplateColumns: '200px '.repeat(2), flexFlow: "column", alignItems: "start" }}>
+    <div style={{ display: "grid", gridTemplateColumns: '200px '.repeat(2), justifyItems: 'left', flexFlow: "column", alignItems: "start" }}>
       <label className="my-label">
         <input
           type="checkbox"


### PR DESCRIPTION
The ui panel above the portraits seemed like it went too far down, so giving more space to the parameters helps to better see more portraits