### PR TITLE
Fix broken links

### DIFF
--- a/src/About.tsx
+++ b/src/About.tsx
@@ -89,7 +89,7 @@ export default function About() {
         <Typography>
           If you have created or want to learn how to create sprites, you can
           join the #sprite-asset-help channel of the{" "}
-          <Link href='"https://discord.gg/skytemple"'>
+          <Link href="https://discord.gg/skytemple">
             SkyTemple discord server
           </Link>
           . Talk to the friendly artists there and they'll help walk you through

--- a/src/components/bar.tsx
+++ b/src/components/bar.tsx
@@ -37,7 +37,7 @@ export function Bar() {
         <IconButton
           size="large"
           color="inherit"
-          href="https://twitter.com/PMD_Spritebot"
+          href="https://github.com/PMDCollab/SpriteCollab"
         >
           <GitHubIcon />
           <Typography variant="h6">Github</Typography>


### PR DESCRIPTION
The GitHub button in the top bar redirected to the Twitter page, and the Discord link on the About page redirected to a GitHub 404 page. I fixed both of these.