### PR TITLE
rendering optimizations

### DIFF
--- a/src/components/display-parameters.tsx
+++ b/src/components/display-parameters.tsx
@@ -28,7 +28,7 @@ export default function DisplayParameters({
           control={
             <Checkbox
               checked={splitForms}
-              onChange={(e) => {
+              onChange={async (e) => {
                 setShowForms(e.target.checked)
                 setSplitForms(e.target.checked)
               }}
@@ -40,7 +40,7 @@ export default function DisplayParameters({
           control={
             <Checkbox
               checked={showUnnecessary}
-              onChange={(e) => {
+              onChange={async (e) => {
                 setShowUnnecessary(e.target.checked);
               }}
             />
@@ -52,7 +52,7 @@ export default function DisplayParameters({
             <Checkbox
               disabled={!splitForms}
               checked={showForms && splitForms}
-              onChange={(e) => {
+              onChange={async (e) => {
                 setShowForms(e.target.checked);
               }}
             />
@@ -68,7 +68,7 @@ export default function DisplayParameters({
               control={
                 <Checkbox
                   checked={state}
-                  onChange={(e) => {
+                  onChange={async (e) => {
                     setState(e.target.checked)
                   }}
                 />

--- a/src/components/pokemon-carousel.tsx
+++ b/src/components/pokemon-carousel.tsx
@@ -1,8 +1,9 @@
 /* eslint-disable no-case-declarations */
-import { useMemo } from "react"
+import { useEffect, useMemo, useState } from "react"
 import { Monster, MonsterForm, useCarrouselQuery } from "../generated/graphql"
 import { RankMethod } from "../types/enum"
 import PokemonThumbnail from "./pokemon-thumbnail"
+// import IntermediateComponent from './intermediate-component'
 import { Grid, Skeleton, Typography } from "@mui/material"
 import {
   getFormMaxPortraitBounty,
@@ -129,6 +130,7 @@ export default function PokemonCarousel({
   showUnnecessary,
   showForms
 }: Props) {
+  const [limitedLoad, setLimitedLoad] = useState<boolean>(true);
   const doesShowParameters = Object.fromEntries(
     Object.entries(showParameters).map(([paramType, { state: [showParam] }]) => [paramType, showParam])
   )
@@ -172,6 +174,9 @@ export default function PokemonCarousel({
         spriteBounty
     }
   })
+  useEffect(() => {
+    setLimitedLoad((loading && data && limitedLoad) ?? true)
+  }, [data])
   const visibleMonsters = useMemo(() => {
     const monsterForms = (data?.monster.flatMap((monster) =>
       splitForms ? monster.forms?.map((form, formIndex) => ({ ...form, monster, formIndex })) ?? [] :
@@ -192,20 +197,24 @@ export default function PokemonCarousel({
   return (
     <Grid container spacing={2} justifyContent={"center"}>
       {loading
-        ? Array.from({ length: 100 }, (_, i) => (
-          <Grid item key={i}>
-            <Skeleton width={80} height={111} variant="rectangular" />
-          </Grid>
-        ))
-        : visibleMonsters.map((form, i) => (
+        ? Array.from({ length: 100 }, (_, i) => <Grid item key={i}>
+          <Skeleton width={80} height={111} variant="rectangular" />
+        </Grid>)
+        // : <IntermediateComponent
+        // visibleMonsters={visibleMonsters}
+        // splitForms={splitForms}
+        // doesShowParameters={doesShowParameters}
+        // showForms={showForms} />}
+
+        : visibleMonsters.map((form, i) => (!limitedLoad || i < 151) && (
           <Grid item key={i}>
             <PokemonThumbnail
-              infoKey={form.monster.rawId}
-              form={form}
-              isSpeciesThumbnail={!splitForms}
-              doesShowParameters={doesShowParameters}
-              showForms={showForms}
-            />
+                infoKey={form.monster.rawId}
+                form={form}
+                isSpeciesThumbnail={!splitForms}
+                doesShowParameters={doesShowParameters}
+                showForms={showForms}
+              />
           </Grid>
         ))}
     </Grid>

--- a/src/components/pokemon-ranking.tsx
+++ b/src/components/pokemon-ranking.tsx
@@ -17,7 +17,7 @@ export default function PokemonRanking({ showParameters, rankBy, setRankBy }: Pr
         labelId="rank-by-label"
         id="rank-by"
         value={rankBy}
-        onChange={(e) => {
+        onChange={async (e) => {
           const selectedRankMethod = e.target.value as RankMethod;
           Object.values(showParameters)
             .find(({ value }) => value == selectedRankMethod)

--- a/src/components/pokemon-thumbnail.tsx
+++ b/src/components/pokemon-thumbnail.tsx
@@ -37,6 +37,7 @@ export default function PokemonThumbnail({
           <img
             src={form.portraits.previewEmotion.url}
             style={{ height: 80, imageRendering: "pixelated" }}
+            loading='lazy'
           />
         ) : (
           // TODO: Fix margin so that the image and text line up perfectly (6.93333px gap) -sec
@@ -59,12 +60,12 @@ export default function PokemonThumbnail({
         </Typography>}
         {portraitAuthor && (
           <Typography align="center" color="GrayText" noWrap sx={textBoxWithResize(form.portraits.creditPrimary?.name)}>
-            {form.portraits.creditPrimary?.name}
+            {form.portraits.creditPrimary?.name ?? "N/A"}
           </Typography>
         )}
         {spriteAuthor && (
           <Typography align="center" color="GrayText" noWrap sx={textBoxWithResize(form.sprites.creditPrimary?.name)}>
-            {form.sprites.creditPrimary?.name}
+            {form.sprites.creditPrimary?.name ?? "N/A"}
           </Typography>
         )}
         {lastModification && (

--- a/src/components/search.tsx
+++ b/src/components/search.tsx
@@ -10,7 +10,7 @@ export default function Search({ currentText, setCurrentText }: {
       fullWidth
       label="Mewtwo... Emmuffin... 151..."
       value={currentText}
-      onChange={({ target: { value } }) => setCurrentText(value)}
+      onChange={async ({ target: { value } }) => setCurrentText(value)}
     />
   )
 }


### PR DESCRIPTION
The site as it went on began to degrade in performance, so it's about time we start cutting down on rendering to optimize the initial page load. There are a few minor changes, but the best improvement in performance so far as been rendering one section of components, and then rendering the rest. This may not load all the content, but it helps with not having the user wait for  seconds to render 3000 components.

other changes:
- changed the thumbnail loading method to lazy to prevent slow loading times for the whole site
- onChange events in parameters are now asynchronous to show the change without having to wait for the full page load