### PR TITLE
project refactorings in state and filter functionality

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -155,11 +155,11 @@
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.22.13",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.22.13.tgz",
-      "integrity": "sha512-XktuhWlJ5g+3TJXc5upd9Ks1HutSArik6jf2eAjYFyIOf4ej3RN+184cZbzDvbPnuTJIUhPKKJE3cIsYTiAT3w==",
+      "version": "7.23.5",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.23.5.tgz",
+      "integrity": "sha512-CgH3s1a96LipHCmSUmYFPwY7MNx8C3avkq7i4Wl3cfa662ldtUe4VM1TPXX70pfmrlWTb6jLqTYrZyT2ZTJBgA==",
       "dependencies": {
-        "@babel/highlight": "^7.22.13",
+        "@babel/highlight": "^7.23.4",
         "chalk": "^2.4.2"
       },
       "engines": {
@@ -260,11 +260,11 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.22.15",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.22.15.tgz",
-      "integrity": "sha512-Zu9oWARBqeVOW0dZOjXc3JObrzuqothQ3y/n1kUtrjCoCPLkXUwMvOo/F/TCfoHMbWIFlWwpZtkZVb9ga4U2pA==",
+      "version": "7.23.6",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.23.6.tgz",
+      "integrity": "sha512-qrSfCYxYQB5owCmGLbl8XRpX1ytXlpueOb0N0UmQwA073KZxejgQTzAmJezxvpwQD9uGtK2shHdi55QT+MbjIw==",
       "dependencies": {
-        "@babel/types": "^7.22.15",
+        "@babel/types": "^7.23.6",
         "@jridgewell/gen-mapping": "^0.3.2",
         "@jridgewell/trace-mapping": "^0.3.17",
         "jsesc": "^2.5.1"
@@ -332,12 +332,12 @@
       }
     },
     "node_modules/@babel/helper-function-name": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.22.5.tgz",
-      "integrity": "sha512-wtHSq6jMRE3uF2otvfuD3DIvVhOsSNshQl0Qrd7qC9oQJzHvOL4qQXlQn2916+CXGywIjpGuIkoyZRRxHPiNQQ==",
+      "version": "7.23.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.23.0.tgz",
+      "integrity": "sha512-OErEqsrxjZTJciZ4Oo+eoZqeW9UIiOcuYKRJA4ZAgV9myA+pOXhhmpfNCKjEH/auVfEYVFJ6y1Tc4r0eIApqiw==",
       "dependencies": {
-        "@babel/template": "^7.22.5",
-        "@babel/types": "^7.22.5"
+        "@babel/template": "^7.22.15",
+        "@babel/types": "^7.23.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -468,9 +468,9 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.22.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.22.5.tgz",
-      "integrity": "sha512-mM4COjgZox8U+JcXQwPijIZLElkgEpO5rsERVDJTc2qfCDfERyob6k5WegS14SX18IIjv+XD+GrqNumY5JRCDw==",
+      "version": "7.23.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.23.4.tgz",
+      "integrity": "sha512-803gmbQdqwdf4olxrX4AJyFBV/RTr3rSmOj0rKwesmzlfhYNDEs+/iOcznzpNWlJlIlTJC2QfPFcHB6DlzdVLQ==",
       "engines": {
         "node": ">=6.9.0"
       }
@@ -505,9 +505,9 @@
       }
     },
     "node_modules/@babel/highlight": {
-      "version": "7.22.20",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.22.20.tgz",
-      "integrity": "sha512-dkdMCN3py0+ksCgYmGG8jKeGA/8Tk+gJwSYYlFGxG5lmhfKNoAy004YpLxpS1W2J8m/EK2Ew+yOs9pVRwO89mg==",
+      "version": "7.23.4",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.23.4.tgz",
+      "integrity": "sha512-acGdbYSfp2WheJoJm/EBBBLh/ID8KDc64ISZ9DYtBmC8/Q204PZJLHyzeB5qMzJ5trcOkybd78M4x2KWsUq++A==",
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.22.20",
         "chalk": "^2.4.2",
@@ -574,9 +574,9 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.22.16",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.22.16.tgz",
-      "integrity": "sha512-+gPfKv8UWeKKeJTUxe59+OobVcrYHETCsORl61EmSkmgymguYk/X5bp7GuUIXaFsc6y++v8ZxPsLSSuujqDphA==",
+      "version": "7.23.6",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.6.tgz",
+      "integrity": "sha512-Z2uID7YJ7oNvAI20O9X0bblw7Qqs8Q2hFy0R9tAfnfLkp5MW0UH9eUvnDSnFwKZ0AvgS1ucqR4KzvVHgnke1VQ==",
       "bin": {
         "parser": "bin/babel-parser.js"
       },
@@ -1026,19 +1026,19 @@
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.22.20",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.22.20.tgz",
-      "integrity": "sha512-eU260mPZbU7mZ0N+X10pxXhQFMGTeLb9eFS0mxehS8HZp9o1uSnFeWQuG1UPrlxgA7QoUzFhOnilHDp0AXCyHw==",
+      "version": "7.23.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.7.tgz",
+      "integrity": "sha512-tY3mM8rH9jM0YHFGyfC0/xf+SB5eKUu7HPj7/k3fpi9dAlsMc5YbQvDi0Sh2QTPXqMhyaAtzAr807TIyfQrmyg==",
       "dependencies": {
-        "@babel/code-frame": "^7.22.13",
-        "@babel/generator": "^7.22.15",
+        "@babel/code-frame": "^7.23.5",
+        "@babel/generator": "^7.23.6",
         "@babel/helper-environment-visitor": "^7.22.20",
-        "@babel/helper-function-name": "^7.22.5",
+        "@babel/helper-function-name": "^7.23.0",
         "@babel/helper-hoist-variables": "^7.22.5",
         "@babel/helper-split-export-declaration": "^7.22.6",
-        "@babel/parser": "^7.22.16",
-        "@babel/types": "^7.22.19",
-        "debug": "^4.1.0",
+        "@babel/parser": "^7.23.6",
+        "@babel/types": "^7.23.6",
+        "debug": "^4.3.1",
         "globals": "^11.1.0"
       },
       "engines": {
@@ -1046,12 +1046,12 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.22.19",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.22.19.tgz",
-      "integrity": "sha512-P7LAw/LbojPzkgp5oznjE6tQEIWbp4PkkfrZDINTro9zgBRtI324/EYsiSI7lhPbpIQ+DCeR2NNmMWANGGfZsg==",
+      "version": "7.23.6",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.6.tgz",
+      "integrity": "sha512-+uarb83brBzPKN38NX1MkB6vb6+mwvR6amUulqAE7ccQw1pEl+bCia9TbdG1lsnFP7lZySvUn37CHyXQdfTwzg==",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.22.5",
-        "@babel/helper-validator-identifier": "^7.22.19",
+        "@babel/helper-string-parser": "^7.23.4",
+        "@babel/helper-validator-identifier": "^7.22.20",
         "to-fast-properties": "^2.0.0"
       },
       "engines": {
@@ -5716,9 +5716,9 @@
       "license": "ISC"
     },
     "node_modules/nanoid": {
-      "version": "3.3.6",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.6.tgz",
-      "integrity": "sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==",
+      "version": "3.3.7",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz",
+      "integrity": "sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==",
       "funding": [
         {
           "type": "github",
@@ -6104,9 +6104,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.30",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.30.tgz",
-      "integrity": "sha512-7ZEao1g4kd68l97aWG/etQKPKq07us0ieSZ2TnFDk11i0ZfDW2AwKHYU8qv4MZKqN2fdBfg+7q0ES06UA73C1g==",
+      "version": "8.4.33",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.33.tgz",
+      "integrity": "sha512-Kkpbhhdjw2qQs2O2DGX+8m5OVqEcbB9HRBvuYM9pgrjEFUg30A9LmXNlTAUj4S9kgtGyrMbTzVjH7E+s5Re2yg==",
       "funding": [
         {
           "type": "opencollective",
@@ -6122,7 +6122,7 @@
         }
       ],
       "dependencies": {
-        "nanoid": "^3.3.6",
+        "nanoid": "^3.3.7",
         "picocolors": "^1.0.0",
         "source-map-js": "^1.0.2"
       },
@@ -7108,9 +7108,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "4.4.9",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-4.4.9.tgz",
-      "integrity": "sha512-2mbUn2LlUmNASWwSCNSJ/EG2HuSRTnVNaydp6vMCm5VIqJsjMfbIWtbH2kDuwUVW5mMUKKZvGPX/rqeqVvv1XA==",
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-4.5.2.tgz",
+      "integrity": "sha512-tBCZBNSBbHQkaGyhGCDUGqeo2ph8Fstyp6FMSvTtsXeZSPpSMGlviAOav2hxVTqFcx8Hj/twtWKsMJXNY0xI8w==",
       "dependencies": {
         "esbuild": "^0.18.10",
         "postcss": "^8.4.27",

--- a/src/Home.tsx
+++ b/src/Home.tsx
@@ -23,25 +23,25 @@ import { Filter, Toggle } from './types/params'
 export default function Home({ ids, meta }: { ids: number[]; meta: Meta }) {
   const [currentText, setCurrentText] = useState("");
   const [rankBy, setRankBy] = useState<RankMethod>(RankMethod.POKEDEX_NUMBER);
-  const [splitForms, setSplitForms] = useState<boolean>(false);
+  const splitFormState = useState<boolean>(false), [splitForms] = splitFormState;
   const unnecessaryState = useState<boolean>(false), [showUnnecessary] = unnecessaryState;
   const showFormState = useState<boolean>(false), [showForms] = showFormState;
-  const toggleState = useState<Record<Toggle, boolean>>({
-    index: false,
-    portraitAuthor: false,
-    spriteAuthor: false,
-    lastModification: false,
-    portraitBounty: false,
-    spriteBounty: false
-  }), [toggles, setToggles] = toggleState;
-  const filterState = useState<Record<Filter, boolean>>({
-    fullyFeaturedPortraits: false,
-    fullyFeaturedSprites: false,
-    existingPortraits: false,
-    existingSprites: false,
-    incompletePortraits: false,
-    incompleteSprites: false
-  }), [filters] = filterState;
+  const toggleState = useState(new Map<Toggle, boolean>([
+    ["index", false],
+    ["portraitAuthor", false],
+    ["spriteAuthor", false],
+    ["lastModification", false],
+    ["portraitBounty", false],
+    ["spriteBounty", false]
+  ])), [toggles, setToggles] = toggleState;
+  const filterState = useState(new Map<Filter, boolean>([
+    ['fullyFeaturedPortraits', false],
+    ['existingPortraits', false],
+    ['incompletePortraits', false],
+    ['fullyFeaturedSprites', false],
+    ['existingSprites', false],
+    ['incompleteSprites', false]
+  ])), [filters] = filterState;
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down("md"));
 
@@ -79,8 +79,7 @@ export default function Home({ ids, meta }: { ids: number[]; meta: Meta }) {
                 <DisplayParameters
                   toggleState={toggleState}
                   filterState={filterState}
-                  splitForms={splitForms}
-                  setSplitForms={setSplitForms}
+                  splitFormState={splitFormState}
                   unnecessaryState={unnecessaryState}
                   showFormState={showFormState}
                 />

--- a/src/Home.tsx
+++ b/src/Home.tsx
@@ -1,10 +1,10 @@
 import PokemonCarousel from "./components/pokemon-carousel"
 import Search from "./components/search"
-import { Dispatch, SetStateAction, useState } from "react"
+import { useState } from "react"
 import { RankMethod } from "./types/enum"
 import DisplayParameters from "./components/display-parameters"
 import PokemonRanking from "./components/pokemon-ranking"
-import { Meta, Phase } from "./generated/graphql"
+import { Meta } from "./generated/graphql"
 import {
   Accordion,
   AccordionDetails,
@@ -18,19 +18,7 @@ import {
 import { Bar } from "./components/bar"
 import { Footer } from "./components/footer"
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore"
-import { Toggle, UseState } from './types/params'
-
-// TODO: Move to extra types file
-export interface Parameters<T> {
-  state: [boolean, Dispatch<SetStateAction<boolean>>]
-  name: string
-  value: T
-}
-
-export interface PhaseCategory {
-  type: 'sprites' | 'portraits'
-  phase: Phase
-}
+import { Filter, Toggle } from './types/params'
 
 export default function Home({ ids, meta }: { ids: number[]; meta: Meta }) {
   const [currentText, setCurrentText] = useState("");
@@ -46,15 +34,14 @@ export default function Home({ ids, meta }: { ids: number[]; meta: Meta }) {
     portraitBounty: false,
     spriteBounty: false
   }), [toggles, setToggles] = toggleState;
-  const filterParameters = ['sprites', 'portraits'].flatMap(type => {
-    const typeUpper = type[0].toUpperCase() + type.slice(1);
-    return [
-      { state: useState<boolean>(false), name: `Fully-Featured ${typeUpper}`, value: { type, phase: Phase.Full } },
-      { state: useState<boolean>(false), name: `Existing ${typeUpper}`, value: { type, phase: Phase.Exists } },
-      { state: useState<boolean>(false), name: `Incomplete ${typeUpper}`, value: { type, phase: Phase.Incomplete } },
-    ] as Parameters<PhaseCategory>[];
-  })
-
+  const filterState = useState<Record<Filter, boolean>>({
+    fullyFeaturedPortraits: false,
+    fullyFeaturedSprites: false,
+    existingPortraits: false,
+    existingSprites: false,
+    incompletePortraits: false,
+    incompleteSprites: false
+  }), [filters] = filterState;
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down("md"));
 
@@ -91,7 +78,7 @@ export default function Home({ ids, meta }: { ids: number[]; meta: Meta }) {
               <AccordionDetails>
                 <DisplayParameters
                   toggleState={toggleState}
-                  filterParameters={filterParameters}
+                  filterState={filterState}
                   splitForms={splitForms}
                   setSplitForms={setSplitForms}
                   unnecessaryState={unnecessaryState}
@@ -111,7 +98,7 @@ export default function Home({ ids, meta }: { ids: number[]; meta: Meta }) {
           currentText={currentText}
           rankBy={rankBy}
           toggles={toggles}
-          filterParameters={filterParameters}
+          filters={filters}
           splitForms={splitForms}
           showUnnecessary={showUnnecessary}
           showForms={showForms}

--- a/src/Home.tsx
+++ b/src/Home.tsx
@@ -18,12 +18,15 @@ import {
 import { Bar } from "./components/bar"
 import { Footer } from "./components/footer"
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore"
+import { Toggle, UseState } from './types/params'
 
+// TODO: Move to extra types file
 export interface Parameters<T> {
   state: [boolean, Dispatch<SetStateAction<boolean>>]
   name: string
   value: T
 }
+
 export interface PhaseCategory {
   type: 'sprites' | 'portraits'
   phase: Phase
@@ -33,24 +36,24 @@ export default function Home({ ids, meta }: { ids: number[]; meta: Meta }) {
   const [currentText, setCurrentText] = useState("");
   const [rankBy, setRankBy] = useState<RankMethod>(RankMethod.POKEDEX_NUMBER);
   const [splitForms, setSplitForms] = useState<boolean>(false);
-  const [showUnnecessary, setShowUnnecessary] = useState<boolean>(false);
-  const [showForms, setShowForms] = useState<boolean>(false);
-  const showParameters: Record<string, Parameters<RankMethod>> = {
-    index: { state: useState<boolean>(false), name: "Index", value: RankMethod.POKEDEX_NUMBER },
-    portraitAuthor: { state: useState<boolean>(false), name: "Portrait Author", value: RankMethod.PORTRAIT_AUTHOR },
-    spriteAuthor: { state: useState<boolean>(false), name: "Sprite Author", value: RankMethod.SPRITE_AUTHOR },
-    lastModification: { state: useState<boolean>(false), name: "Last Change", value: RankMethod.LAST_MODIFICATION },
-    portraitBounty: { state: useState<boolean>(false), name: "Portrait Bounty", value: RankMethod.PORTRAIT_BOUNTY },
-    spriteBounty: { state: useState<boolean>(false), name: "Sprite Bounty", value: RankMethod.SPRITE_BOUNTY }
-  };
+  const unnecessaryState = useState<boolean>(false), [showUnnecessary] = unnecessaryState;
+  const showFormState = useState<boolean>(false), [showForms] = showFormState;
+  const toggleState = useState<Record<Toggle, boolean>>({
+    index: false,
+    portraitAuthor: false,
+    spriteAuthor: false,
+    lastModification: false,
+    portraitBounty: false,
+    spriteBounty: false
+  }), [toggles, setToggles] = toggleState;
   const filterParameters = ['sprites', 'portraits'].flatMap(type => {
-      const typeUpper = type[0].toUpperCase() + type.slice(1);
-      return [
-        { state: useState<boolean>(false), name: `Fully-Featured ${typeUpper}`, value: { type, phase: Phase.Full } },
-        { state: useState<boolean>(false), name: `Existing ${typeUpper}`, value: { type, phase: Phase.Exists } },
-        { state: useState<boolean>(false), name: `Incomplete ${typeUpper}`, value: { type, phase: Phase.Incomplete } },
-      ] as Parameters<PhaseCategory>[];
-    })
+    const typeUpper = type[0].toUpperCase() + type.slice(1);
+    return [
+      { state: useState<boolean>(false), name: `Fully-Featured ${typeUpper}`, value: { type, phase: Phase.Full } },
+      { state: useState<boolean>(false), name: `Existing ${typeUpper}`, value: { type, phase: Phase.Exists } },
+      { state: useState<boolean>(false), name: `Incomplete ${typeUpper}`, value: { type, phase: Phase.Incomplete } },
+    ] as Parameters<PhaseCategory>[];
+  })
 
   const theme = useTheme();
   const isMobile = useMediaQuery(theme.breakpoints.down("md"));
@@ -87,16 +90,15 @@ export default function Home({ ids, meta }: { ids: number[]; meta: Meta }) {
               </AccordionSummary>
               <AccordionDetails>
                 <DisplayParameters
-                showParameters={showParameters}
-                filterParameters={filterParameters}
-                splitForms={splitForms}
-                setSplitForms={setSplitForms}
-                showUnnecessary={showUnnecessary}
-                setShowUnnecessary={setShowUnnecessary}
-                showForms={showForms}
-                setShowForms={setShowForms} />
+                  toggleState={toggleState}
+                  filterParameters={filterParameters}
+                  splitForms={splitForms}
+                  setSplitForms={setSplitForms}
+                  unnecessaryState={unnecessaryState}
+                  showFormState={showFormState}
+                />
                 <PokemonRanking
-                  showParameters={showParameters}
+                  setToggles={setToggles}
                   setRankBy={setRankBy}
                   rankBy={rankBy}
                 />
@@ -108,7 +110,7 @@ export default function Home({ ids, meta }: { ids: number[]; meta: Meta }) {
         <PokemonCarousel
           currentText={currentText}
           rankBy={rankBy}
-          showParameters={showParameters}
+          toggles={toggles}
           filterParameters={filterParameters}
           splitForms={splitForms}
           showUnnecessary={showUnnecessary}

--- a/src/components/display-parameters.tsx
+++ b/src/components/display-parameters.tsx
@@ -1,18 +1,17 @@
 import { Checkbox, FormControlLabel, Grid, Typography } from "@mui/material"
-import { Parameters, PhaseCategory } from '../Home'
 import { Dispatch, SetStateAction } from "react"
-import { Toggle, UseState, toggleToName } from '../types/params'
+import { Filter, Toggle, UseState, filterToName, toggleToName } from '../types/params'
 
 interface Props {
   toggleState: UseState<Record<Toggle, boolean>>
-  filterParameters: Parameters<PhaseCategory>[]
+  filterState: UseState<Record<Filter, boolean>>
   splitForms: boolean
   setSplitForms: Dispatch<SetStateAction<boolean>>
   unnecessaryState: UseState<boolean>
   showFormState: UseState<boolean>
 }
 export default function DisplayParameters({
-  toggleState: [toggles, setToggle], filterParameters,
+  toggleState: [toggles, setToggle], filterState: [filters, setFilter],
   splitForms, setSplitForms,
   unnecessaryState: [showUnnecessary, setShowUnnecessary],
   showFormState: [showForms, setShowForms],
@@ -58,28 +57,44 @@ export default function DisplayParameters({
         />
       </Grid>
       {/* TODO: add filter params back */}
-      {[Object.entries(toggles)].map((params, i) =>
-        <Grid item key={i + 1}>
-          <Typography sx={{ fontWeight: "bold" }}>{!i ? "Toggles" : "Filters"}</Typography>
-          {params.map(([toggle, isShowing]) => (
-            <FormControlLabel
-              label={<Typography color="text.secondary">{toggleToName[toggle as Toggle]}</Typography>}
-              control={
-                <Checkbox
-                  checked={isShowing}
-                  onChange={async (e) => {
-                    setToggle(toggles => ({
-                      ...toggles,
-                      [toggle]: e.target.checked
-                    }))
-                  }}
-                />
-              }
-              key={toggle}
-            />
-          ))}
-        </Grid>
-      )}
+      <Grid item >
+        <Typography sx={{ fontWeight: "bold" }}>Toggles</Typography>
+        {Object.entries(toggles).map(([toggle, isShowing]) => (
+          <FormControlLabel
+            label={<Typography color="text.secondary">{toggleToName[toggle]}</Typography>}
+            control={
+              <Checkbox
+                checked={isShowing}
+                onChange={async (e) => {
+                  setToggle(toggles => ({
+                    ...toggles,
+                    [toggle]: e.target.checked
+                  }))
+                }}
+              />
+            }
+          />
+        ))}
+      </Grid>
+      <Grid item>
+        <Typography sx={{ fontWeight: "bold" }}>Filters</Typography>
+        {Object.entries(filters).map(([filter, isShowing]) => (
+          <FormControlLabel
+            label={<Typography color="text.secondary">{filterToName[filter]}</Typography>}
+            control={
+              <Checkbox
+                checked={isShowing}
+                onChange={async (e) => {
+                  setFilter(filters => ({
+                    ...filters,
+                    [filter]: e.target.checked
+                  }))
+                }}
+              />
+            }
+          />
+        ))}
+      </Grid>
     </Grid>
   )
 }

--- a/src/components/display-parameters.tsx
+++ b/src/components/display-parameters.tsx
@@ -1,18 +1,17 @@
 import { Checkbox, FormControlLabel, Grid, Typography } from "@mui/material"
-import { Dispatch, SetStateAction } from "react"
-import { Filter, Toggle, UseState, filterToName, toggleToName } from '../types/params'
+import { Filter, Toggle, UseState, filterNames, toggleNames } from '../types/params'
+import { Fragment } from 'react'
 
 interface Props {
-  toggleState: UseState<Record<Toggle, boolean>>
-  filterState: UseState<Record<Filter, boolean>>
-  splitForms: boolean
-  setSplitForms: Dispatch<SetStateAction<boolean>>
+  toggleState: UseState<Map<Toggle, boolean>>
+  filterState: UseState<Map<Filter, boolean>>
+  splitFormState: UseState<boolean>
   unnecessaryState: UseState<boolean>
   showFormState: UseState<boolean>
 }
 export default function DisplayParameters({
   toggleState: [toggles, setToggle], filterState: [filters, setFilter],
-  splitForms, setSplitForms,
+  splitFormState: [splitForms, setSplitForms],
   unnecessaryState: [showUnnecessary, setShowUnnecessary],
   showFormState: [showForms, setShowForms],
 }: Props) {
@@ -56,43 +55,40 @@ export default function DisplayParameters({
           }
         />
       </Grid>
-      {/* TODO: add filter params back */}
-      <Grid item >
+      <Grid item key={1}>
         <Typography sx={{ fontWeight: "bold" }}>Toggles</Typography>
-        {Object.entries(toggles).map(([toggle, isShowing]) => (
+        {[...toggles.entries()].map(([toggle, isShowing]) => (
           <FormControlLabel
-            label={<Typography color="text.secondary">{toggleToName[toggle]}</Typography>}
+            label={<Typography color="text.secondary">{toggleNames[toggle]}</Typography>}
             control={
               <Checkbox
                 checked={isShowing}
                 onChange={async (e) => {
-                  setToggle(toggles => ({
-                    ...toggles,
-                    [toggle]: e.target.checked
-                  }))
+                  setToggle(new Map(toggles.set(toggle, e.target.checked)))
                 }}
               />
             }
+            key={toggle}
           />
         ))}
       </Grid>
-      <Grid item>
+      <Grid item key={2}>
         <Typography sx={{ fontWeight: "bold" }}>Filters</Typography>
-        {Object.entries(filters).map(([filter, isShowing]) => (
-          <FormControlLabel
-            label={<Typography color="text.secondary">{filterToName[filter]}</Typography>}
-            control={
-              <Checkbox
-                checked={isShowing}
-                onChange={async (e) => {
-                  setFilter(filters => ({
-                    ...filters,
-                    [filter]: e.target.checked
-                  }))
-                }}
-              />
-            }
-          />
+        {[...filters.entries()].map(([filter, isShowing], index) => (
+          <Fragment key={filter}>
+            {index == 3 && <br />}
+            <FormControlLabel
+              label={<Typography color="text.secondary">{filterNames[filter]}</Typography>}
+              control={
+                <Checkbox
+                  checked={isShowing}
+                  onChange={async (e) => {
+                    setFilter(new Map(filters.set(filter, e.target.checked)))
+                  }}
+                />
+              }
+            />
+          </Fragment>
         ))}
       </Grid>
     </Grid>

--- a/src/components/display-parameters.tsx
+++ b/src/components/display-parameters.tsx
@@ -1,23 +1,21 @@
 import { Checkbox, FormControlLabel, Grid, Typography } from "@mui/material"
 import { Parameters, PhaseCategory } from '../Home'
-import { RankMethod } from "../types/enum"
 import { Dispatch, SetStateAction } from "react"
+import { Toggle, UseState, toggleToName } from '../types/params'
 
 interface Props {
-  showParameters: Record<string, Parameters<RankMethod>>
+  toggleState: UseState<Record<Toggle, boolean>>
   filterParameters: Parameters<PhaseCategory>[]
   splitForms: boolean
   setSplitForms: Dispatch<SetStateAction<boolean>>
-  showUnnecessary: boolean
-  setShowUnnecessary: Dispatch<SetStateAction<boolean>>
-  showForms: boolean
-  setShowForms: Dispatch<SetStateAction<boolean>>
+  unnecessaryState: UseState<boolean>
+  showFormState: UseState<boolean>
 }
 export default function DisplayParameters({
-  showParameters, filterParameters,
+  toggleState: [toggles, setToggle], filterParameters,
   splitForms, setSplitForms,
-  showUnnecessary, setShowUnnecessary,
-  showForms, setShowForms
+  unnecessaryState: [showUnnecessary, setShowUnnecessary],
+  showFormState: [showForms, setShowForms],
 }: Props) {
   return (
     <Grid container spacing={2}>
@@ -59,21 +57,25 @@ export default function DisplayParameters({
           }
         />
       </Grid>
-      {[Object.values(showParameters), filterParameters].map((params, i) =>
+      {/* TODO: add filter params back */}
+      {[Object.entries(toggles)].map((params, i) =>
         <Grid item key={i + 1}>
           <Typography sx={{ fontWeight: "bold" }}>{!i ? "Toggles" : "Filters"}</Typography>
-          {params.map(({ state: [state, setState], name }) => (
+          {params.map(([toggle, isShowing]) => (
             <FormControlLabel
-              label={<Typography color="text.secondary">{name}</Typography>}
+              label={<Typography color="text.secondary">{toggleToName[toggle as Toggle]}</Typography>}
               control={
                 <Checkbox
-                  checked={state}
+                  checked={isShowing}
                   onChange={async (e) => {
-                    setState(e.target.checked)
+                    setToggle(toggles => ({
+                      ...toggles,
+                      [toggle]: e.target.checked
+                    }))
                   }}
                 />
               }
-              key={name}
+              key={toggle}
             />
           ))}
         </Grid>

--- a/src/components/display-parameters.tsx
+++ b/src/components/display-parameters.tsx
@@ -1,6 +1,7 @@
 import { Checkbox, FormControlLabel, Grid, Typography } from "@mui/material"
-import { Filter, Toggle, UseState, filterNames, toggleNames } from '../types/params'
+import { Filter, Toggle, filterNames, toggleNames } from '../types/params'
 import { Fragment } from 'react'
+import { UseState } from '../util'
 
 interface Props {
   toggleState: UseState<Map<Toggle, boolean>>

--- a/src/components/pokemon-carousel.tsx
+++ b/src/components/pokemon-carousel.tsx
@@ -9,7 +9,7 @@ import { Filter, Toggle } from '../types/params'
 export type MonsterFormWithRef = MonsterForm & { monster: Monster, formIndex: number }
 
 function getFilterType(filter: Filter): { type: 'sprites' | 'portraits', phase: Phase } {
-  const type = filter.endsWith('sprites') ? 'sprites' : 'portraits';
+  const type = filter.endsWith('Sprites') ? 'sprites' : 'portraits';
   switch (true) {
     case filter.startsWith("fullyFeatured"):
       return { type, phase: Phase.Full };
@@ -97,22 +97,21 @@ function filterMonsterForms(
           css.some(({ name }) => name?.toLowerCase().includes(lowerCaseText))
       ) ||
       id.toString().includes(lowerCaseText))
-  const { portraits: portraitFilters, sprites: spriteFilters } = groupBy([...filters.entries()]
+  const { portraits: portraitFilters = [], sprites: spriteFilters = [] } = groupBy([...filters.entries()]
     .filter(([_, isShowing]) => isShowing)
     .map(([filter]) => getFilterType(filter)),
     (filter) => filter.type);
   // TODO: make this a bit nicer i kinda dont like having to write 4 different filters
-  if (portraitFilters) {
+  if (portraitFilters.length || spriteFilters.length) {
     forms = splitForms
-      ? forms.filter((form) => portraitFilters.some(({ phase }) => phase == form.portraits.phase))
-      : forms.filter(({ monster: { forms } }) => portraitFilters.some(({ phase }) =>
-        forms.some(form => (showUnnecessary || form.portraits.required) && phase == form.portraits.phase)));
-  }
-  if (spriteFilters) {
-    forms = splitForms
-      ? forms.filter((form) => spriteFilters.some(({ phase }) => phase == form.sprites.phase))
-      : forms.filter(({ monster: { forms } }) => spriteFilters.some(({ phase }) =>
-        forms.some(form => (showUnnecessary || form.sprites.required) && phase == form.sprites.phase)));
+      ? forms.filter((form) =>
+        (!portraitFilters.length || portraitFilters.some(({ phase }) => phase == form.portraits.phase))
+        && (!spriteFilters.length || spriteFilters.some(({ phase }) => phase == form.sprites.phase)))
+      : forms.filter(({ monster: { forms } }) =>
+        (!portraitFilters.length || portraitFilters.some(({ phase }) =>
+          forms.some(form => (showUnnecessary || form.portraits.required) && phase == form.portraits.phase)))
+        && (!spriteFilters.length || spriteFilters.some(({ phase }) =>
+          forms.some(form => (showUnnecessary || form.sprites.required) && phase == form.sprites.phase))));
   }
   return forms
     .filter(({ portraits, sprites }) => !splitForms || portraits.required || sprites.required || showUnnecessary)

--- a/src/components/pokemon-carousel.tsx
+++ b/src/components/pokemon-carousel.tsx
@@ -12,6 +12,7 @@ import {
   getMonsterMaxSpriteBounty
 } from "../util"
 import { Parameters, PhaseCategory } from "../Home"
+import { Toggle } from '../types/params'
 
 export type MonsterFormWithRef = MonsterForm & { monster: Monster, formIndex: number }
 
@@ -114,7 +115,7 @@ interface Props {
   currentText: string
   rankBy: RankMethod
   ids: number[]
-  showParameters: Record<string, Parameters<RankMethod>>
+  toggles: Record<Toggle, boolean>
   filterParameters: Parameters<PhaseCategory>[]
   splitForms: boolean
   showUnnecessary: boolean
@@ -124,23 +125,20 @@ export default function PokemonCarousel({
   currentText,
   rankBy,
   ids,
-  showParameters,
+  toggles,
   filterParameters,
   splitForms,
   showUnnecessary,
   showForms
 }: Props) {
   const [limitedLoad, setLimitedLoad] = useState<boolean>(true);
-  const doesShowParameters = Object.fromEntries(
-    Object.entries(showParameters).map(([paramType, { state: [showParam] }]) => [paramType, showParam])
-  )
   const {
     portraitAuthor,
     spriteAuthor,
     portraitBounty,
     spriteBounty,
     lastModification
-  } = doesShowParameters
+  } = toggles;
   const withPortraitPhases = filterParameters.some(
     ({ state: [filterPhases], value: { type } }) => filterPhases && type == "portraits"
   )
@@ -182,6 +180,7 @@ export default function PokemonCarousel({
       splitForms ? monster.forms?.map((form, formIndex) => ({ ...form, monster, formIndex })) ?? [] :
         monster.manual ? { ...monster.manual, monster, formIndex: 0 } : {}
     ) ?? []) as MonsterFormWithRef[];
+    // TODO: move to object containing instead of making new one
     const filters = filterMonsterForms(
       monsterForms,
       splitForms,
@@ -212,7 +211,7 @@ export default function PokemonCarousel({
                 infoKey={form.monster.rawId}
                 form={form}
                 isSpeciesThumbnail={!splitForms}
-                doesShowParameters={doesShowParameters}
+                toggles={toggles}
                 showForms={showForms}
               />
           </Grid>

--- a/src/components/pokemon-informations.tsx
+++ b/src/components/pokemon-informations.tsx
@@ -37,11 +37,7 @@ interface Props {
 export default function PokemonInformations({
   info: { sprites, portraits }
 }: Props) {
-  const bg = useRef<Dungeon>(
-    Object.keys(Dungeon)[
-    Math.floor(Math.random() * Object.keys(Dungeon).length)
-    ] as Dungeon
-  )
+  const bg = useRef<Dungeon>(Object.values(Dungeon)[Math.floor(Math.random() * Object.values(Dungeon).length)]);
   const portraitDate = portraits.modifiedDate && new Date(portraits.modifiedDate)
   const spriteDate = sprites.modifiedDate && new Date(sprites.modifiedDate)
   const portraitSheetUrl = portraits.sheetUrl && (

--- a/src/components/pokemon-ranking.tsx
+++ b/src/components/pokemon-ranking.tsx
@@ -1,14 +1,14 @@
 import { Dispatch, SetStateAction } from "react"
 import { RankMethod } from "../types/enum"
 import { FormControl, InputLabel, MenuItem, Select } from "@mui/material"
-import { Parameters } from '../Home'
+import { Toggle, rankMethodToToggle } from '../types/params'
 
 interface Props {
-  showParameters: Record<string, Parameters<RankMethod>>
+  setToggles: Dispatch<SetStateAction<Record<Toggle, boolean>>>
   rankBy: RankMethod
   setRankBy: Dispatch<SetStateAction<RankMethod>>
 }
-export default function PokemonRanking({ showParameters, rankBy, setRankBy }: Props) {
+export default function PokemonRanking({ setToggles, rankBy, setRankBy }: Props) {
   return (
     <FormControl sx={{ mt: 2 }} fullWidth>
       <InputLabel id="rank-by-label">Rank by</InputLabel>
@@ -19,10 +19,13 @@ export default function PokemonRanking({ showParameters, rankBy, setRankBy }: Pr
         value={rankBy}
         onChange={async (e) => {
           const selectedRankMethod = e.target.value as RankMethod;
-          Object.values(showParameters)
-            .find(({ value }) => value == selectedRankMethod)
-            ?.state[1](true);
           setRankBy(selectedRankMethod);
+          if (selectedRankMethod == RankMethod.NAME) return;
+          const selectedToggle = rankMethodToToggle[selectedRankMethod];
+          setToggles(toggle => ({
+            ...toggle,
+            [selectedToggle]: true
+          }));
         }}
       >
         {Object.values(RankMethod).map((r) => (

--- a/src/components/pokemon-ranking.tsx
+++ b/src/components/pokemon-ranking.tsx
@@ -4,7 +4,7 @@ import { FormControl, InputLabel, MenuItem, Select } from "@mui/material"
 import { Toggle, rankMethodToToggle } from '../types/params'
 
 interface Props {
-  setToggles: Dispatch<SetStateAction<Record<Toggle, boolean>>>
+  setToggles: Dispatch<SetStateAction<Map<Toggle, boolean>>>
   rankBy: RankMethod
   setRankBy: Dispatch<SetStateAction<RankMethod>>
 }

--- a/src/components/pokemon-thumbnail.tsx
+++ b/src/components/pokemon-thumbnail.tsx
@@ -3,18 +3,19 @@ import { Paper, Typography } from "@mui/material"
 import { formatDate, getFormMaxPortraitBounty, getFormMaxSpriteBounty, getMonsterMaxPortraitBounty, getMonsterMaxSpriteBounty, thumbnailScale } from '../util'
 import { MonsterFormWithRef } from "./pokemon-carousel"
 import { Maybe } from '../generated/graphql'
+import { Toggle } from '../types/params'
 
 interface Props {
   form: MonsterFormWithRef
   infoKey: string
-  doesShowParameters: Record<string, boolean>
+  toggles: Record<Toggle, boolean>
   isSpeciesThumbnail?: boolean
   showForms: boolean
 }
 export default function PokemonThumbnail({
   form, form: { monster, formIndex },
   infoKey,
-  doesShowParameters: {
+  toggles: {
     index, spriteAuthor, portraitAuthor, lastModification,
     portraitBounty, spriteBounty
   },

--- a/src/components/pokemon-thumbnail.tsx
+++ b/src/components/pokemon-thumbnail.tsx
@@ -1,6 +1,6 @@
 import { Link } from "react-router-dom"
 import { Paper, Typography } from "@mui/material"
-import { formatDate, getFormMaxPortraitBounty, getFormMaxSpriteBounty, getMonsterMaxPortraitBounty, getMonsterMaxSpriteBounty, thumbnailScale } from '../util'
+import { formatDate, getFormBounty, getMonsterBounty, thumbnailScale } from '../util'
 import { MonsterFormWithRef } from "./pokemon-carousel"
 import { Maybe } from '../generated/graphql'
 import { Toggle } from '../types/params'
@@ -8,20 +8,21 @@ import { Toggle } from '../types/params'
 interface Props {
   form: MonsterFormWithRef
   infoKey: string
-  toggles: Record<Toggle, boolean>
+  toggles: Map<Toggle, boolean>
   isSpeciesThumbnail?: boolean
   showForms: boolean
 }
 export default function PokemonThumbnail({
   form, form: { monster, formIndex },
   infoKey,
-  toggles: {
-    index, spriteAuthor, portraitAuthor, lastModification,
-    portraitBounty, spriteBounty
-  },
+  toggles,
   isSpeciesThumbnail = false,
   showForms
 }: Props) {
+  const {
+    index, spriteAuthor, portraitAuthor, lastModification,
+    portraitBounty, spriteBounty
+  } = Object.fromEntries(toggles);
   const textBoxStyle = { width: 80, height: 25 };
   const textBoxWithResize = (name?: Maybe<string>) => ({
     ...textBoxStyle,
@@ -79,12 +80,12 @@ export default function PokemonThumbnail({
         )}
         {portraitBounty && (
           <Typography color="GrayText" align="center" noWrap sx={textBoxStyle}>
-            {isSpeciesThumbnail ? getMonsterMaxPortraitBounty(monster) : getFormMaxPortraitBounty(form)} gp
+            {isSpeciesThumbnail ? getMonsterBounty(monster ,'portraits') : getFormBounty(form, 'portraits')} gp
           </Typography>
         )}
         {spriteBounty && (
           <Typography color="GrayText" align="center" noWrap sx={textBoxStyle}>
-            {isSpeciesThumbnail ? getMonsterMaxSpriteBounty(monster) : getFormMaxSpriteBounty(form)} gp
+            {isSpeciesThumbnail ? getMonsterBounty(monster, 'sprites') : getFormBounty(form, 'sprites')} gp
           </Typography>
         )}
       </Paper>

--- a/src/types/params.ts
+++ b/src/types/params.ts
@@ -1,0 +1,23 @@
+import { Dispatch, SetStateAction } from 'react';
+import { RankMethod } from './enum';
+
+export type UseState<T> = [T, Dispatch<SetStateAction<T>>];
+export type Toggle = keyof typeof toggleToName;
+
+export const rankMethodToToggle: Record<Exclude<RankMethod, RankMethod.NAME>, Toggle> = {
+  [RankMethod.POKEDEX_NUMBER]: "index",
+  [RankMethod.PORTRAIT_AUTHOR]: "portraitAuthor",
+  [RankMethod.SPRITE_AUTHOR]: "spriteAuthor",
+  [RankMethod.LAST_MODIFICATION]: "lastModification",
+  [RankMethod.PORTRAIT_BOUNTY]: "portraitBounty",
+  [RankMethod.SPRITE_BOUNTY]: "spriteBounty"
+};
+
+export const toggleToName = {
+  index: "Index",
+  portraitAuthor: "Portrait Author",
+  spriteAuthor: "Sprite Author",
+  lastModification: "Last Change",
+  portraitBounty: "Portrait Bounty",
+  spriteBounty: "Sprite Bounty"
+} as const;

--- a/src/types/params.ts
+++ b/src/types/params.ts
@@ -1,13 +1,6 @@
 import { Dispatch, SetStateAction } from 'react';
 import { RankMethod } from './enum';
 
-// Fixes Object.entries keys displaying the wrong type
-declare global {
-  interface ObjectConstructor {
-    entries<T extends object>(o: T): { [K in keyof T]: [K, T[K]]; }[keyof T][];
-  }
-}
-
 export type UseState<T> = [T, Dispatch<SetStateAction<T>>];
 export type Toggle = "index" | "portraitAuthor" | "spriteAuthor" | "lastModification" | "portraitBounty" | "spriteBounty";
 
@@ -20,7 +13,7 @@ export const rankMethodToToggle: Record<Exclude<RankMethod, RankMethod.NAME>, To
   [RankMethod.SPRITE_BOUNTY]: "spriteBounty",
 };
 
-export const toggleToName: Record<Toggle, string> = {
+export const toggleNames: Record<Toggle, string> = {
   index: "Index",
   portraitAuthor: "Portrait Author",
   spriteAuthor: "Sprite Author",
@@ -29,13 +22,14 @@ export const toggleToName: Record<Toggle, string> = {
   spriteBounty: "Sprite Bounty"
 } as const;
 
-export type Filter = `${"fullyFeatured" | "existing" | "incomplete"}${"Sprites" | "Portraits"}`
 
-export const filterToName: Record<Filter, string> = {
+export type Filter = `${"fullyFeatured" | "existing" | "incomplete"}${"Sprites" | "Portraits"}`;
+
+export const filterNames: Record<Filter, string> = {
   fullyFeaturedPortraits: "Fully-Featured Portraits",
-  fullyFeaturedSprites: "Fully-Featured Sprites",
   existingPortraits: "Existing Portraits",
-  existingSprites: "Existing Sprites",
   incompletePortraits: "Incomplete Portraits",
+  fullyFeaturedSprites: "Fully-Featured Sprites",
+  existingSprites: "Existing Sprites",
   incompleteSprites: "Incomplete Sprites"
-}
+};

--- a/src/types/params.ts
+++ b/src/types/params.ts
@@ -1,7 +1,4 @@
-import { Dispatch, SetStateAction } from 'react';
 import { RankMethod } from './enum';
-
-export type UseState<T> = [T, Dispatch<SetStateAction<T>>];
 export type Toggle = "index" | "portraitAuthor" | "spriteAuthor" | "lastModification" | "portraitBounty" | "spriteBounty";
 
 export const rankMethodToToggle: Record<Exclude<RankMethod, RankMethod.NAME>, Toggle> = {

--- a/src/types/params.ts
+++ b/src/types/params.ts
@@ -8,7 +8,7 @@ export const rankMethodToToggle: Record<Exclude<RankMethod, RankMethod.NAME>, To
   [RankMethod.LAST_MODIFICATION]: "lastModification",
   [RankMethod.PORTRAIT_BOUNTY]: "portraitBounty",
   [RankMethod.SPRITE_BOUNTY]: "spriteBounty",
-};
+} as const;
 
 export const toggleNames: Record<Toggle, string> = {
   index: "Index",
@@ -29,4 +29,4 @@ export const filterNames: Record<Filter, string> = {
   fullyFeaturedSprites: "Fully-Featured Sprites",
   existingSprites: "Existing Sprites",
   incompleteSprites: "Incomplete Sprites"
-};
+} as const;

--- a/src/types/params.ts
+++ b/src/types/params.ts
@@ -1,8 +1,15 @@
 import { Dispatch, SetStateAction } from 'react';
 import { RankMethod } from './enum';
 
+// Fixes Object.entries keys displaying the wrong type
+declare global {
+  interface ObjectConstructor {
+    entries<T extends object>(o: T): { [K in keyof T]: [K, T[K]]; }[keyof T][];
+  }
+}
+
 export type UseState<T> = [T, Dispatch<SetStateAction<T>>];
-export type Toggle = keyof typeof toggleToName;
+export type Toggle = "index" | "portraitAuthor" | "spriteAuthor" | "lastModification" | "portraitBounty" | "spriteBounty";
 
 export const rankMethodToToggle: Record<Exclude<RankMethod, RankMethod.NAME>, Toggle> = {
   [RankMethod.POKEDEX_NUMBER]: "index",
@@ -10,10 +17,10 @@ export const rankMethodToToggle: Record<Exclude<RankMethod, RankMethod.NAME>, To
   [RankMethod.SPRITE_AUTHOR]: "spriteAuthor",
   [RankMethod.LAST_MODIFICATION]: "lastModification",
   [RankMethod.PORTRAIT_BOUNTY]: "portraitBounty",
-  [RankMethod.SPRITE_BOUNTY]: "spriteBounty"
+  [RankMethod.SPRITE_BOUNTY]: "spriteBounty",
 };
 
-export const toggleToName = {
+export const toggleToName: Record<Toggle, string> = {
   index: "Index",
   portraitAuthor: "Portrait Author",
   spriteAuthor: "Sprite Author",
@@ -21,3 +28,14 @@ export const toggleToName = {
   portraitBounty: "Portrait Bounty",
   spriteBounty: "Sprite Bounty"
 } as const;
+
+export type Filter = `${"fullyFeatured" | "existing" | "incomplete"}${"Sprites" | "Portraits"}`
+
+export const filterToName: Record<Filter, string> = {
+  fullyFeaturedPortraits: "Fully-Featured Portraits",
+  fullyFeaturedSprites: "Fully-Featured Sprites",
+  existingPortraits: "Existing Portraits",
+  existingSprites: "Existing Sprites",
+  incompletePortraits: "Incomplete Portraits",
+  incompleteSprites: "Incomplete Sprites"
+}

--- a/src/util.tsx
+++ b/src/util.tsx
@@ -1,4 +1,7 @@
+import { Dispatch, SetStateAction } from 'react';
 import { Maybe, Monster, MonsterForm } from './generated/graphql';
+
+export type UseState<T> = [T, Dispatch<SetStateAction<T>>];
 
 const pad = (number: number) => number < 10 ? `0${number}` : number.toString();
 export const thumbnailScale = (str?: Maybe<string>) => Math.max(9 / Math.max(str?.length ?? 0, 9), 0.6);

--- a/src/util.tsx
+++ b/src/util.tsx
@@ -12,19 +12,22 @@ export function getLastModification(t?: Date) {
     return t ? `Modified at ${formatDate(t.getTime())}` : "";
 }
 
-export const getMonsterMaxPortraitBounty = (monster: Monster, useUnnecessary = false) => monster.forms.reduce(
-    (a, b) => !b.portraits.required && !useUnnecessary ? a : Math.max(a, getFormMaxPortraitBounty(b)), 0
-)
-export const getFormMaxPortraitBounty = ({ portraits: { bounty: { exists, full, incomplete } } }: MonsterForm) => Math.max(
-    exists || 0,
-    full || 0,
-    incomplete || 0
-)
-export const getMonsterMaxSpriteBounty = (monster: Monster, useUnnecessary = false) => monster.forms.reduce(
-    (a, b) => !b.sprites.required && !useUnnecessary ? a : Math.max(a, getFormMaxSpriteBounty(b)), 0
-)
-export const getFormMaxSpriteBounty = ({ sprites: { bounty: { exists, full, incomplete } } }: MonsterForm) => Math.max(
-    exists || 0,
-    full || 0,
-    incomplete || 0
-)
+export function getMonsterBounty(monster: Monster, type: 'sprites' | 'portraits', useUnnecessary = false): number {
+    return monster.forms.reduce((a, monster) => {
+        if (!monster.portraits.required && !useUnnecessary) return a;
+        return Math.max(a, getFormBounty(monster, type))
+    }, 0)
+}
+export function getFormBounty(monster: MonsterForm, type: 'sprites' | 'portraits'): number {
+    const { [type]: { bounty: { exists, full, incomplete } } } = monster;
+    return Math.max(exists || 0, full || 0, incomplete || 0);
+}
+
+// TODO: if the new version with Object.groupBy comes around then replace this
+export function groupBy<T, K extends PropertyKey>(arr: T[], cb: (element: T) => K): Partial<Record<K, T[]>> {
+    return arr.reduce((a, element) => {
+        const key = cb(element);
+        (a[key] = a[key] || []).push(element);
+        return a;
+    }, {} as Record<K, T[]>)
+}


### PR DESCRIPTION
it's been a while since i made any new changes but i figured i would merge this in first before working on user requests.

right now parameter state is stored in individual state variables which creates this mess (EW)
![image](https://github.com/PMDCollab/PMD-collab-wiki/assets/67805443/9aa3008c-60e7-47a2-9d4a-7ae530a85d8a)
which is basically unreadable to me and other people. the project now uses a more maintainable version using maps for proper ordering:
![image](https://github.com/PMDCollab/PMD-collab-wiki/assets/67805443/a6b31ebf-5913-4cfd-b78b-12fea198cd72)
most of the metadata for toggles and filters have been moved to [types/param.ts](https://github.com/PMDCollab/PMD-collab-wiki/pull/69/files#diff-1666f5b0d3d38b2c1add488147cfe85eebfbf7f6025dbe51a070c44d08a0f41d) which contains the necessary records and types to export.

no new performance improvements or features were added except for more useful filtering. In the past, if at least one filter applied to the form, then it would be valid. this isn't too useful for much users, so the functionality has been changed.
![image](https://github.com/PMDCollab/PMD-collab-wiki/assets/67805443/5e5614e3-5ed5-45a6-ae83-f58f4b2b60cf)
along with sprites and portraits now being categorized under separate filters (implicitly) the filter now requires that the form matches BOTH any portrait filter and any sprite filter. if a form fits in the portrait category but not the sprite category, they will not be visible and vice versa.

![image](https://github.com/PMDCollab/PMD-collab-wiki/assets/67805443/6954d89f-ca15-4a3b-9780-c3b6f19ec86f)
(here it only shows forms that are fully completed in both portraits and sprites)