### PR TITLE
fix incorrect use of useState on maps

### DIFF
--- a/src/components/display-parameters.tsx
+++ b/src/components/display-parameters.tsx
@@ -16,7 +16,6 @@ export default function DisplayParameters({
   unnecessaryState: [showUnnecessary, setShowUnnecessary],
   showFormState: [showForms, setShowForms],
 }: Props) {
-  console.log(toggles)
   return (
     <Grid container spacing={2}>
       <Grid item key={0}>

--- a/src/components/display-parameters.tsx
+++ b/src/components/display-parameters.tsx
@@ -16,6 +16,7 @@ export default function DisplayParameters({
   unnecessaryState: [showUnnecessary, setShowUnnecessary],
   showFormState: [showForms, setShowForms],
 }: Props) {
+  console.log(toggles)
   return (
     <Grid container spacing={2}>
       <Grid item key={0}>
@@ -65,7 +66,7 @@ export default function DisplayParameters({
               <Checkbox
                 checked={isShowing}
                 onChange={async (e) => {
-                  setToggle(new Map(toggles.set(toggle, e.target.checked)))
+                  setToggle(prev => new Map([...prev, [toggle, e.target.checked]]))
                 }}
               />
             }
@@ -84,7 +85,7 @@ export default function DisplayParameters({
                 <Checkbox
                   checked={isShowing}
                   onChange={async (e) => {
-                    setFilter(new Map(filters.set(filter, e.target.checked)))
+                    setFilter(prev => new Map([...prev, [filter, e.target.checked]]))
                   }}
                 />
               }

--- a/src/components/pokemon-ranking.tsx
+++ b/src/components/pokemon-ranking.tsx
@@ -22,10 +22,7 @@ export default function PokemonRanking({ setToggles, rankBy, setRankBy }: Props)
           setRankBy(selectedRankMethod);
           if (selectedRankMethod == RankMethod.NAME) return;
           const selectedToggle = rankMethodToToggle[selectedRankMethod];
-          setToggles(toggle => ({
-            ...toggle,
-            [selectedToggle]: true
-          }));
+          setToggles(toggle => new Map([...toggle, [selectedToggle, true]]));
         }}
       >
         {Object.values(RankMethod).map((r) => (

--- a/src/types/params.ts
+++ b/src/types/params.ts
@@ -8,7 +8,7 @@ export const rankMethodToToggle: Record<Exclude<RankMethod, RankMethod.NAME>, To
   [RankMethod.LAST_MODIFICATION]: "lastModification",
   [RankMethod.PORTRAIT_BOUNTY]: "portraitBounty",
   [RankMethod.SPRITE_BOUNTY]: "spriteBounty",
-};
+} as const;
 
 export const toggleNames: Record<Toggle, string> = {
   index: "Index",
@@ -29,4 +29,4 @@ export const filterNames: Record<Filter, string> = {
   fullyFeaturedSprites: "Fully-Featured Sprites",
   existingSprites: "Existing Sprites",
   incompleteSprites: "Incomplete Sprites"
-};
+} as const;


### PR DESCRIPTION
current implementation makes a new map with only one key, new one uses spread op on all keys and adds the last key so toggles and ranking doesn't break