### PR TITLE
reverting phaser

### DIFF
--- a/src/About.tsx
+++ b/src/About.tsx
@@ -42,9 +42,9 @@ export default function About() {
         <Typography>
           Custom sprites are licensed under <Link href="http://creativecommons.org/licenses/by-nc/4.0/?ref=chooser-v1">Attribution-NonCommercial 4.0 International</Link>. All acceptable use of custom sprites must be done with <Link href="https://wiki.creativecommons.org/wiki/Recommended_practices_for_attribution">appropriate credit</Link>.  We recommend including a file or link of the <Link href="https://github.com/PMDCollab/SpriteCollab/blob/master/credit_names.txt">credit_names.txt</Link>, which contains all authors of the project.
         </Typography>
-        <Container sx={{ mb: 2 }}>
+        <Container sx={{ mb: 2, mt: 2 }}>
           <Grid container spacing={2} justifyContent="space-around">
-            <Grid>
+            <Grid item>
               <Card>
                 <CardContent>
                   <Typography align="center" variant="h5">
@@ -89,7 +89,7 @@ export default function About() {
                 </CardActions>
               </Card>
             </Grid>
-            <Grid>
+            <Grid item>
               <Card>
                 <CardContent>
                   <Typography align="center" variant="h5">

--- a/src/Home.tsx
+++ b/src/Home.tsx
@@ -21,7 +21,7 @@ import ExpandMoreIcon from "@mui/icons-material/ExpandMore"
 import { Filter, Toggle } from "./types/params"
 
 export default function Home({ ids, meta }: { ids: number[]; meta: Meta }) {
-  const [currentText, setCurrentText] = useState("");
+  const textState = useState(""), [currentText] = textState;
   const [rankBy, setRankBy] = useState<RankMethod>(RankMethod.POKEDEX_NUMBER);
   const splitFormState = useState<boolean>(false), [splitForms] = splitFormState;
   const unnecessaryState = useState<boolean>(false), [showUnnecessary] = unnecessaryState;
@@ -67,8 +67,7 @@ export default function Home({ ids, meta }: { ids: number[]; meta: Meta }) {
           >
             Search for a pokemon, artist or pokedex number ...
           </Typography>
-          <Search currentText={currentText} setCurrentText={setCurrentText} />
-          {!isMobile && (
+          <Search textState={textState} />
             <Accordion sx={{ mt: 2 }}>
               <AccordionSummary expandIcon={<ExpandMoreIcon />}>
                 <Typography color="text.secondary">
@@ -90,7 +89,6 @@ export default function Home({ ids, meta }: { ids: number[]; meta: Meta }) {
                 />
               </AccordionDetails>
             </Accordion>
-          )}
         </Container>
 
         <PokemonCarousel

--- a/src/components/pokemon-page.tsx
+++ b/src/components/pokemon-page.tsx
@@ -23,7 +23,7 @@ export default function PokemonPage({ infoKey, prevIndex, nextIndex, rawId }: Pr
   let phaserWindows: GameContainer[] = [];
   function reset() {
     for (const window of phaserWindows) {
-      window.game.destroy(false);
+      window.game.destroy(true);
     }
     console.log(phaserWindows.length)
   }

--- a/src/components/pokemon-thumbnail.tsx
+++ b/src/components/pokemon-thumbnail.tsx
@@ -1,5 +1,5 @@
 import { Link } from "react-router-dom"
-import { Paper, Typography } from "@mui/material"
+import { Paper, Typography, useMediaQuery, useTheme } from "@mui/material"
 import { formatDate, getFormBounty, getMonsterBounty, thumbnailScale } from '../util'
 import { MonsterFormWithRef } from "./pokemon-carousel"
 import { Maybe } from '../generated/graphql'
@@ -19,31 +19,33 @@ export default function PokemonThumbnail({
   isSpeciesThumbnail = false,
   showForms
 }: Props) {
+  const boxScale = useMediaQuery(useTheme().breakpoints.down("md")) ? 0.75 : 1;
+  const boxSize = 80 * boxScale;
   const {
     index, spriteAuthor, portraitAuthor, lastModification,
     portraitBounty, spriteBounty
   } = Object.fromEntries(toggles);
-  const textBoxStyle = { width: 80, height: 25 };
+
+  const textBoxStyle = { width: boxSize, height: 25 * boxScale };
   const textBoxWithResize = (name?: Maybe<string>) => ({
     ...textBoxStyle,
-    fontSize: `${thumbnailScale(name)}em`,
-    lineHeight: `${1.2 / thumbnailScale(name)}em`
+    fontSize: `${thumbnailScale(name) * boxScale}em`,
+    lineHeight: `${1.2 / thumbnailScale(name)* boxScale}em`
   })
   return (
-    <Link to={`/${infoKey}?form=${formIndex}`}>
+    <Link to={`/${infoKey}?form=${formIndex}`} style={{ transform: "scale(0.5)" }}>
       <Paper
-        sx={{ minWidth: 80 }}
+        sx={{ minWidth: boxSize }}
         elevation={2}
       >
         {form.portraits.previewEmotion?.url ? (
           <img
             src={form.portraits.previewEmotion.url}
-            style={{ height: 80, imageRendering: "pixelated" }}
+            style={{ height: boxSize, imageRendering: "pixelated" }}
             loading='lazy'
           />
         ) : (
-          // TODO: Fix margin so that the image and text line up perfectly (6.93333px gap) -sec
-          <Typography variant="h4" align="center" sx={{ height: 80, display: "grid", marginBottom: 13 / 15, placeItems: "center" }}>
+          <Typography variant="h4" align="center" sx={{ height: boxSize, display: "grid", marginBottom: 13 / 15, placeItems: "center" }}>
             ?
           </Typography>
         )}
@@ -57,7 +59,7 @@ export default function PokemonThumbnail({
             {form.fullName}
           </Typography>
         )}
-        {index && <Typography align="center" color="GrayText" noWrap sx={{ width: 80, height: 25 }}>
+        {index && <Typography align="center" color="GrayText" noWrap sx={{ width: boxSize, height: 25 }}>
           {infoKey}
         </Typography>}
         {portraitAuthor && (
@@ -71,7 +73,7 @@ export default function PokemonThumbnail({
           </Typography>
         )}
         {lastModification && (
-          <Typography align="center" color="GrayText" noWrap sx={textBoxStyle}>
+          <Typography align="center" color="GrayText" noWrap sx={textBoxStyle} fontSize={16 * boxScale}>
             {formatDate(Math.max( // TODO: this sucks rewrite it
               form.portraits.modifiedDate && new Date(form.portraits.modifiedDate).getTime() || 0,
               form.sprites.modifiedDate && new Date(form.sprites.modifiedDate).getTime() || 0
@@ -79,12 +81,12 @@ export default function PokemonThumbnail({
           </Typography>
         )}
         {portraitBounty && (
-          <Typography color="GrayText" align="center" noWrap sx={textBoxStyle}>
-            {isSpeciesThumbnail ? getMonsterBounty(monster ,'portraits') : getFormBounty(form, 'portraits')} gp
+          <Typography color="GrayText" align="center" noWrap sx={textBoxStyle} fontSize={16 * boxScale}>
+            {isSpeciesThumbnail ? getMonsterBounty(monster, 'portraits') : getFormBounty(form, 'portraits')} gp
           </Typography>
         )}
         {spriteBounty && (
-          <Typography color="GrayText" align="center" noWrap sx={textBoxStyle}>
+          <Typography color="GrayText" align="center" noWrap sx={textBoxStyle} fontSize={16 * boxScale}>
             {isSpeciesThumbnail ? getMonsterBounty(monster, 'sprites') : getFormBounty(form, 'sprites')} gp
           </Typography>
         )}

--- a/src/components/search.tsx
+++ b/src/components/search.tsx
@@ -1,9 +1,7 @@
 import { TextField } from "@mui/material"
+import { UseState } from '../util'
 
-export default function Search({ currentText, setCurrentText }: {
-  currentText: string
-  setCurrentText: React.Dispatch<React.SetStateAction<string>>
-}) {
+export default function Search({ textState: [currentText, setCurrentText] }: { textState: UseState<string> }) {
   return (
     <TextField
       sx={{ backgroundColor: "white" }}

--- a/src/components/sprite-preview.tsx
+++ b/src/components/sprite-preview.tsx
@@ -25,6 +25,7 @@ export default function SpritePreview({ sprite, dungeon, animData, history }: Pr
         )
       }
 
+      // TODO: the phaser instance isn't being destroyed on page change, this seriously needs to be fixed
       if (node !== null) {
         gameContainer.current?.game.destroy(true)
       }


### PR DESCRIPTION
changed to old method of parsing xml to prevent phaser problems
fixed https://github.com/PMDCollab/PMD-collab-wiki/issues/45 where changing tabs in information pages would cause a memory leak because of duplicate phaser instances being carried to the next route without being destroyed