### PR TITLE
Credits Mode is now available for public use!

### DIFF
--- a/src/Home.tsx
+++ b/src/Home.tsx
@@ -10,9 +10,7 @@ import {
   AccordionDetails,
   AccordionSummary,
   Box,
-  Checkbox,
   Container,
-  FormControlLabel,
   Link,
   Typography,
   useMediaQuery,
@@ -23,7 +21,7 @@ import { Footer } from "./components/footer"
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore"
 import { Filter, MiscParams, Toggle, filters, miscParams, paramsToMap, paramsToObject, toggles } from "./types/params"
 import { SetURLSearchParams, useSearchParams } from 'react-router-dom'
-import { UseState, toggleParamCallback } from './util'
+import { UseState } from './util'
 
 export const Context = createContext<{
   searchParamsState: [URLSearchParams, SetURLSearchParams]
@@ -37,7 +35,7 @@ export default function Home({ ids, meta }: { ids: number[]; meta: Meta }) {
   const textState = useState(""), [currentText] = textState;
   const rankState = useState<RankMethod>(RankMethod.POKEDEX_NUMBER);
   // the lord the savior use search params
-  const searchParamsState = useSearchParams(), [searchParams, setSearchParams] = searchParamsState;
+  const searchParamsState = useSearchParams(), [searchParams] = searchParamsState;
   // TODO: make these objects instead of maps
   const toggleState = paramsToMap<Toggle, boolean>(searchParams, toggles, Boolean);
   const filterState = paramsToMap<Filter, boolean>(searchParams, filters, Boolean);
@@ -50,16 +48,7 @@ export default function Home({ ids, meta }: { ids: number[]; meta: Meta }) {
     <Context.Provider value={{ searchParamsState, toggleState, filterState, miscState, rankState }}>
       <Box>
         <Bar />
-        {/* TODO: put this in a different component */}
         <Container maxWidth="xl" sx={{ backgroundColor: "rgba(255,255,255,.9)" }}>
-          {searchParams.get("beta") === "true" && <FormControlLabel
-            sx={{ position: 'absolute' }}
-            label={<Typography color="text.secondary">Credits Mode</Typography>}
-            control={<Checkbox
-              checked={miscState.creditsMode}
-              onChange={async e => setSearchParams(toggleParamCallback('creditsMode', e.target.checked))}
-            />}
-          />}
           <Typography
             variant={isMobile ? "subtitle2" : "h5"}
             align="center"

--- a/src/components/display-parameters.tsx
+++ b/src/components/display-parameters.tsx
@@ -1,4 +1,4 @@
-import { Checkbox, FormControlLabel, Grid, Typography } from "@mui/material"
+import { Checkbox, FormControlLabel, Grid, Link, Typography } from "@mui/material"
 import { filterNames, toggleNames } from '../types/params'
 import { Fragment, useContext } from 'react'
 import { Context } from '../Home'
@@ -19,7 +19,7 @@ export default function DisplayParameters() {
   return (
     <Grid container spacing={2}>
       <Grid item key={0} xs={12}>
-        <Typography sx={{ fontWeight: "bold" }}>Credits (New!)</Typography>
+        <Typography sx={{ fontWeight: "bold" }}>Credits <Link href="https://github.com/PMDCollab/PMD-collab-wiki/pull/100">(New!)</Link></Typography>
         <FormControlLabel
           label={<Typography color="text.secondary">Credits Mode</Typography>}
           control={<Checkbox

--- a/src/components/display-parameters.tsx
+++ b/src/components/display-parameters.tsx
@@ -18,7 +18,17 @@ export default function DisplayParameters() {
   } = miscState;
   return (
     <Grid container spacing={2}>
-      <Grid item key={0}>
+      <Grid item key={0} xs={12}>
+        <Typography sx={{ fontWeight: "bold" }}>Credits (New!)</Typography>
+        <FormControlLabel
+          label={<Typography color="text.secondary">Credits Mode</Typography>}
+          control={<Checkbox
+            checked={miscState.creditsMode}
+            onChange={async e => setSearchParams(toggleParamCallback('creditsMode', e.target.checked))}
+          />}
+        />
+      </Grid>
+      <Grid item key={1} xs={12}>
         <Typography sx={{ fontWeight: "bold" }}>Forms View</Typography>
         <FormControlLabel
           label={<Typography color="text.secondary">Split Forms</Typography>}
@@ -52,7 +62,7 @@ export default function DisplayParameters() {
           }
         />
       </Grid>
-      <Grid item key={1}>
+      <Grid item key={2} xs={12}>
         <Typography sx={{ fontWeight: "bold" }}>Toggles</Typography>
         {[...toggleState.entries()].map(([toggle, isShowing]) => (
           <FormControlLabel
@@ -67,7 +77,7 @@ export default function DisplayParameters() {
           />
         ))}
       </Grid>
-      <Grid item key={2}>
+      <Grid item key={3} xs={12}>
         <Typography sx={{ fontWeight: "bold" }}>Filters</Typography>
         {[...filterState.entries()].map(([filter, isShowing], index) => (
           <Fragment key={filter}>

--- a/src/components/pokemon-carousel.tsx
+++ b/src/components/pokemon-carousel.tsx
@@ -218,6 +218,7 @@ export default function PokemonCarousel({
 
   return <>
     {creditsMode && <div>
+      {!splitForms && <h3>WARNING: Split Forms is not enabled. You will only generate credits for the first form of each sprite.</h3>}
       <Button variant="contained" onClick={() => generateCredits(visibleMonsters, creditedMonsRef.current!)} style={{ margin: '10px' }}>Download Credits!</Button>
     </div>}
     <Grid container spacing={2} justifyContent={"center"}>

--- a/src/components/pokemon-carousel.tsx
+++ b/src/components/pokemon-carousel.tsx
@@ -218,7 +218,7 @@ export default function PokemonCarousel({
 
   return <>
     {creditsMode && <div>
-      {!splitForms && <h3>WARNING: Split Forms is not enabled. You will only generate credits for the first form of each sprite.</h3>}
+      {!splitForms && <h3>WARNING: Split Forms is not enabled. You will only generate credits for the main form of each sprite. (i.e. shinies not included)</h3>}
       <Button variant="contained" onClick={() => generateCredits(visibleMonsters, creditedMonsRef.current!)} style={{ margin: '10px' }}>Download Credits!</Button>
     </div>}
     <Grid container spacing={2} justifyContent={"center"}>

--- a/src/components/pokemon-thumbnail.tsx
+++ b/src/components/pokemon-thumbnail.tsx
@@ -5,7 +5,6 @@ import { MonsterFormWithRef } from "./pokemon-carousel"
 import { Maybe } from '../generated/graphql'
 import { MutableRefObject, useContext } from 'react'
 import { Context } from '../Home'
-import './thing.css';
 
 interface Props {
   form: MonsterFormWithRef

--- a/src/components/pokemon-thumbnail.tsx
+++ b/src/components/pokemon-thumbnail.tsx
@@ -92,7 +92,7 @@ export default function PokemonThumbnail({
   </Paper>
   return creditsMode ?
     <div className="credit-label">
-      <label htmlFor={uniqueName}>
+      <label htmlFor={uniqueName} style={{ cursor: 'pointer' }}>
         <input type="checkbox" name={uniqueName} id={uniqueName} ref={el => creditedMonsRef.current[uniqueName] = el} />
         {insideThumbnail}
       </label>

--- a/src/index.css
+++ b/src/index.css
@@ -10,9 +10,9 @@ strong > .with-credit {
 }
 
 .credit-label {
-  outline: 3px solid red;
+  outline: 3px solid lightgray;
   border-radius: 5px;
-  color: red;
+  color: lightgray;
 }
 
 .credit-label input[type="checkbox"] {
@@ -20,6 +20,6 @@ strong > .with-credit {
 }
 
 .credit-label:has(input[type="checkbox"]:checked) {
-  outline: 3px solid green;
-  color: green;
+  outline: 3px solid lime;
+  color: lime;
 }


### PR DESCRIPTION
For a while formally crediting artists in SpriteCollab has been a hassle, and crediting all sprites is a bit impractical for ROM hacks or videos that only use a small subset. Credits Mode allows you to select the sprites and portraits you used, and bundles it into a file to reference when properly crediting artists. Previously this feature was only available by marking a search parameter, but now it's available to all.

To get started, open up the searching options tab and click the Credits Mode checkbox.
![image](https://github.com/user-attachments/assets/ff32714a-241f-4aaa-8217-9d256833f558)

You can now select and deselect pokemon and forms as much as you'd like. If you want to include all forms, make sure to check the "Split Forms" checkbox too.
![image](https://github.com/user-attachments/assets/f1c434a0-34e3-48f9-baf9-a476bf75cfae)
